### PR TITLE
Webdriver: create fallback for webdriver_manager

### DIFF
--- a/tweetcapture/utils/webdriver.py
+++ b/tweetcapture/utils/webdriver.py
@@ -24,6 +24,9 @@ async def get_driver(custom_options=None, driver_path=None):
     chrome_options.add_experimental_option(
         'excludeSwitches', ['enable-logging'])
 
-    driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=chrome_options)
+    try:
+        driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=chrome_options)
+    except:
+        driver = webdriver.Chrome(executable_path=driver_path, options=chrome_options)
 
     return driver


### PR DESCRIPTION
when we set 'set_chromedriver_path' we want to use a custom (or systems) chromedriver path.

The current behaviour seems to trigger an update by webdriver_manager for chromedriver and forces to use that chromedriver version, which is not always friendly for the current chromium releases available for the users distro.

By catching an exception we can use the custom 'set_chromedriver_path' again. It seems to starting misbehaving in this commit:

https://github.com/Xacnio/tweetcapture/commit/82e1e8e87ce4e00349d586ac44fd4d683bf5074d#diff-fdd48d5baf89a7e3ec83ddbd57d6757af98e6fcd0d6267741b1a5fe3288ebf77L22

Signed-off-by: Erik Castricum <git@cas-online.nl>